### PR TITLE
feat: add `prettier` optionally and replace `eslint-plugin-tailwindcss` with `eslint-plugin-better-tailwindcss`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,8 @@
         "christian-kohler.npm-intellisense",
         "dbaeumer.vscode-eslint",
         "VisualStudioExptTeam.vscodeintellicode",
-        "wix.vscode-import-cost"
+        "wix.vscode-import-cost",
+        "esbenp.prettier-vscode"
       ]
     }
   },

--- a/.prettierrc.mjs
+++ b/.prettierrc.mjs
@@ -1,0 +1,2 @@
+import { prettier } from '@cewald/eslint-config'
+export default prettier

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "typescript.tsdk": "node_modules/typescript/lib",
-  "editor.formatOnSave": false,
+  "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "always"
-  },
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "typescript.tsdk": "node_modules/typescript/lib",
   "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "always"
   }

--- a/README.md
+++ b/README.md
@@ -22,15 +22,25 @@ It should be applied to all JS/TS projects to unify the company coding-styles.
 
 1. For autoformat on save in VSCode, add VSCode settings to workspace settings in `.vscode/settings.json`:
 
-   ```json
-   {
-     "editor.formatOnSave": true,
-     "editor.defaultFormatter": "esbenp.prettier-vscode",
-     "editor.codeActionsOnSave": {
-       "source.fixAll.eslint": "always"
+   - When using `prettier`:
+     ```json
+     {
+       "editor.formatOnSave": true,
+       "editor.defaultFormatter": "esbenp.prettier-vscode",
+       "editor.codeActionsOnSave": {
+         "source.fixAll.eslint": "always"
+       }
      }
-   }
-   ```
+     ```
+   - When not using `prettier`:
+     ```json
+     {
+       "editor.formatOnSave": false,
+       "editor.codeActionsOnSave": {
+         "source.fixAll.eslint": "always"
+       }
+     }
+     ```
 
 1. Add linting commands to `package.json`:
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It should be applied to all JS/TS projects to unify the company coding-styles.
    ```js
    import config from '@cewald/eslint-config'
 
-   export default [ ...config() ]
+   export default [...config()]
    ```
 
 1. For autoformat on save in VSCode, add VSCode settings to workspace settings in `.vscode/settings.json`:
@@ -25,9 +25,9 @@ It should be applied to all JS/TS projects to unify the company coding-styles.
    ```json
    {
      "editor.formatOnSave": false,
-      "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": "always"
-      }
+     "editor.codeActionsOnSave": {
+       "source.fixAll.eslint": "always"
+     }
    }
    ```
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ It should be applied to all JS/TS projects to unify the company coding-styles.
 
    ```json
    {
-     "editor.formatOnSave": false,
+     "editor.formatOnSave": true,
+     "editor.defaultFormatter": "esbenp.prettier-vscode",
      "editor.codeActionsOnSave": {
        "source.fixAll.eslint": "always"
      }

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -2,6 +2,6 @@
  * @type {import('semantic-release').GlobalConfig}
  */
 export default {
-  branches: [ 'main' ],
-  extends: [ '@commitlint/config-conventional' ],
+  branches: ['main'],
+  extends: ['@commitlint/config-conventional'],
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,8 +3,11 @@ import tsEslint from 'typescript-eslint'
 import config from '@cewald/eslint-config'
 
 export default [
-  { ignores: [ 'node_modules', 'dist' ] },
+  { ignores: ['node_modules', 'dist'] },
   pluginJs.configs.recommended,
   ...tsEslint.configs.recommended,
-  ...config({ initVuePlugin: true, initStylisticPlugin: true }),
+  ...config({
+    initVuePlugin: true,
+    useStylisticPlugin: false,
+  }),
 ]

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,5 +6,5 @@ export default [
   { ignores: [ 'node_modules', 'dist' ] },
   pluginJs.configs.recommended,
   ...tsEslint.configs.recommended,
-  ...config({ initVuePlugin: true }),
+  ...config({ initVuePlugin: true, initStylisticPlugin: true }),
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "deepmerge": "^4.3.1",
         "eslint": "^9.9.1",
         "eslint-config-prettier": "^10.1.5",
+        "eslint-plugin-better-tailwindcss": "^3.4.1",
         "eslint-plugin-tailwindcss": "^3.17.4",
         "prettier": "^3.5.3"
       },
@@ -669,6 +670,19 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@eslint/css-tree": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@eslint/css-tree/-/css-tree-3.6.1.tgz",
+      "integrity": "sha512-5DIsBME23tUQD5zHD+T38lC2DG4jB8x8JRa+yDncLne2TIZA0VuCpcSazOX1EC+sM/q8w24qeevXfmfsIxAeqA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.21.0",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
@@ -1072,6 +1086,18 @@
       "peer": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.7.tgz",
+      "integrity": "sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -2761,6 +2787,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
+      "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/env-ci": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-11.1.0.tgz",
@@ -2903,6 +2942,54 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-better-tailwindcss": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-better-tailwindcss/-/eslint-plugin-better-tailwindcss-3.4.1.tgz",
+      "integrity": "sha512-0H6uvPwi9FcoIusrIhjTru/3C1ieKqQVc4kSleGfbv/oKdYtUjl290gSd/gs23et4E7UmegC8e64Jb7pDRiQFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@eslint/css-tree": "^3.6.1",
+        "enhanced-resolve": "^5.18.1",
+        "jiti": "^2.4.2",
+        "postcss": "^8.5.6",
+        "postcss-import": "^16.1.1",
+        "synckit": "^0.11.8",
+        "tailwind-csstree": "^0.1.1"
+      },
+      "engines": {
+        "node": "^20.11.0 || >=21.2.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0",
+        "tailwindcss": "^3.3.0 || ^4.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-better-tailwindcss/node_modules/jiti": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/eslint-plugin-better-tailwindcss/node_modules/postcss-import": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-16.1.1.tgz",
+      "integrity": "sha512-2xVS1NCZAfjtVdvXiyegxzJ447GyqCeEI5V7ApgQVOWnros1p5lGNovJNapwPpMombyFBfqDwt7AD3n2l0KOfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
       }
     },
     "node_modules/eslint-plugin-tailwindcss": {
@@ -3298,7 +3385,6 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -3518,7 +3604,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -3564,7 +3649,6 @@
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -3803,7 +3887,6 @@
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
       "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -4635,6 +4718,12 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.21.0.tgz",
+      "integrity": "sha512-+ZKPQezM5vYJIkCxaC+4DTnRrVZR1CgsKLu5zsQERQx6Tea8Y+wMx5A24rq8A8NepCeatIQufVAekKNgiBMsGQ==",
+      "license": "CC0-1.0"
+    },
     "node_modules/meow": {
       "version": "12.1.1",
       "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
@@ -4792,9 +4881,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "funding": [
         {
           "type": "github",
@@ -7737,8 +7826,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
@@ -7767,9 +7855,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -7801,7 +7889,6 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7894,9 +7981,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.41",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.41.tgz",
-      "integrity": "sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==",
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
       "funding": [
         {
           "type": "opencollective",
@@ -7913,9 +8000,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.0.1",
-        "source-map-js": "^1.2.0"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -8051,8 +8138,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -8175,7 +8261,6 @@
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pify": "^2.3.0"
       }
@@ -8316,7 +8401,6 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -8862,9 +8946,9 @@
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -9159,12 +9243,39 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.8.tgz",
+      "integrity": "sha512-+XZ+r1XGIJGeQk3VvXhT6xx/VpbHsRzsTkGgF6E5RX9TTXD0118l87puaEBZ566FhqblC6U0d4XnubznJDm30A==",
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.2.4"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tailwind-csstree": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tailwind-csstree/-/tailwind-csstree-0.1.1.tgz",
+      "integrity": "sha512-Tv5IXRHtlb7LanNXjmGg0vu84Iu+/sKDqTLJBO0kP/rggfjJDKnS/HV+e0qn8yIrRByhGg+908rSOxT/7o1diw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/tailwindcss": {
@@ -9203,6 +9314,15 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tapable": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
+      "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/temp-dir": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "eslint": "^9.9.1",
         "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-better-tailwindcss": "^3.4.1",
-        "eslint-plugin-tailwindcss": "^3.17.4",
         "prettier": "^3.5.3"
       },
       "devDependencies": {
@@ -3031,22 +3030,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-tailwindcss": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-tailwindcss/-/eslint-plugin-tailwindcss-3.18.0.tgz",
-      "integrity": "sha512-PQDU4ZMzFH0eb2DrfHPpbgo87Zgg2EXSMOj1NSfzdZm+aJzpuwGerfowMIaVehSREEa0idbf/eoNYAOHSJoDAQ==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-glob": "^3.2.5",
-        "postcss": "^8.4.4"
-      },
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "tailwindcss": "^3.4.0"
       }
     },
     "node_modules/eslint-plugin-vue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
         "@stylistic/eslint-plugin": "^4.0.0",
         "deepmerge": "^4.3.1",
         "eslint": "^9.9.1",
-        "eslint-plugin-tailwindcss": "^3.17.4"
+        "eslint-config-prettier": "^10.1.5",
+        "eslint-plugin-tailwindcss": "^3.17.4",
+        "prettier": "^3.5.3"
       },
       "devDependencies": {
         "@cewald/eslint-config": "./",
@@ -25,7 +27,8 @@
         "typescript-eslint": "^8.3.0"
       },
       "peerDependencies": {
-        "eslint": "^9.9.1"
+        "eslint": "^9.9.1",
+        "prettier": "^3.5.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2885,6 +2888,21 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
+      "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-plugin-tailwindcss": {
@@ -8030,6 +8048,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-ms": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "deepmerge": "^4.3.1",
     "eslint": "^9.9.1",
     "eslint-config-prettier": "^10.1.5",
-    "eslint-plugin-tailwindcss": "^3.17.4",
+    "eslint-plugin-better-tailwindcss": "^3.4.1",
     "prettier": "^3.5.3"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -44,13 +44,17 @@
     "@stylistic/eslint-plugin": "^4.0.0",
     "deepmerge": "^4.3.1",
     "eslint": "^9.9.1",
-    "eslint-plugin-tailwindcss": "^3.17.4"
+    "eslint-config-prettier": "^10.1.5",
+    "eslint-plugin-tailwindcss": "^3.17.4",
+    "prettier": "^3.5.3"
   },
   "peerDependencies": {
-    "eslint": "^9.9.1"
+    "eslint": "^9.9.1",
+    "prettier": "^3.5.3"
   },
   "lint-staged": {
     "*": [
+      "prettier --write --ignore-unknown",
       "npm run lint:fix"
     ]
   },

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -2,7 +2,6 @@
  * @type {import('semantic-release').GlobalConfig}
  */
 export default {
-  branches: [ 'main' ],
   plugins: [
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ export const config = (props: ConfigProps) => {
           ? {
               'better-tailwindcss/no-unregistered-classes': [
                 'warn',
-                { detectComponentClasses: 'never' },
+                { detectComponentClasses: true },
               ],
             }
           : {}),

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export { default as prettier } from './prettier.js'
 
 export type ConfigProps = {
   initVuePlugin?: boolean
+  useStylisticPlugin?: boolean
   initStylisticPlugin?: boolean
   stylistic?: StylisticCustomizeOptions
   tailwindcss?: boolean
@@ -18,6 +19,7 @@ export type ConfigProps = {
 
 const DefaultConfigProps: ConfigProps = {
   initVuePlugin: false,
+  useStylisticPlugin: true,
   initStylisticPlugin: false,
   tailwindcss: true,
   tailwindcssConfig: {},
@@ -26,6 +28,7 @@ const DefaultConfigProps: ConfigProps = {
 export const config = (props: ConfigProps) => {
   const {
     initVuePlugin,
+    useStylisticPlugin,
     initStylisticPlugin,
     stylistic: stylisticConfig,
     tailwindcss,
@@ -34,56 +37,58 @@ export const config = (props: ConfigProps) => {
   const confArray = []
 
   if (tailwindcss) {
-    const { customClassProperties, ...tailwindcssConfigRest }
-      = tailwindcssConfig
+    const { customClassProperties, ...tailwindcssConfigRest } =
+      tailwindcssConfig
     confArray.push(...pluginTailwindCSS.configs['flat/recommended'])
     confArray.push({
       settings: {
         tailwindcss: merge(
           {
-            cssFiles: [ 'src/**/*.{css,scss}' ],
+            cssFiles: ['src/**/*.{css,scss}'],
             classRegex: customClassProperties
-              ? `^(${[ 'class(Name)?', ...customClassProperties ].join('|')})$`
+              ? `^(${['class(Name)?', ...customClassProperties].join('|')})$`
               : undefined,
           },
-          tailwindcssConfigRest
+          tailwindcssConfigRest,
         ),
       },
     })
   }
 
-  if (initStylisticPlugin) {
-    confArray.push(stylistic.configs.customize(stylisticConfig))
-  }
+  if (useStylisticPlugin) {
+    if (initStylisticPlugin) {
+      confArray.push(stylistic.configs.customize(stylisticConfig))
+    }
 
-  confArray.push({
-    rules: {
-      '@stylistic/max-len': [ 'error', { code: 120 } ],
-      '@stylistic/quotes': [
-        2,
-        'single',
-        { avoidEscape: true, allowTemplateLiterals: false },
-      ],
-      '@stylistic/arrow-parens': [ 'error', 'as-needed' ],
-      '@stylistic/brace-style': [ 'error', '1tbs', { allowSingleLine: true } ],
-      '@stylistic/array-bracket-spacing': [ 'error', 'always' ],
-      '@stylistic/comma-dangle': [
-        'error',
-        {
-          arrays: 'always-multiline',
-          objects: 'always-multiline',
-          imports: 'always-multiline',
-          exports: 'always-multiline',
-          functions: 'never',
-        },
-      ],
-      '@stylistic/block-spacing': [ 'error', 'always' ],
-      '@stylistic/computed-property-spacing': [ 'error' ],
-      '@stylistic/operator-linebreak': [ 'error' ],
-      '@stylistic/function-call-spacing': [ 'error' ],
-      '@stylistic/function-paren-newline': [ 'error' ],
-    },
-  })
+    confArray.push({
+      rules: {
+        '@stylistic/max-len': ['error', { code: 120 }],
+        '@stylistic/quotes': [
+          2,
+          'single',
+          { avoidEscape: true, allowTemplateLiterals: false },
+        ],
+        '@stylistic/arrow-parens': ['error', 'as-needed'],
+        '@stylistic/brace-style': ['error', '1tbs', { allowSingleLine: true }],
+        '@stylistic/array-bracket-spacing': ['error', 'always'],
+        '@stylistic/comma-dangle': [
+          'error',
+          {
+            arrays: 'always-multiline',
+            objects: 'always-multiline',
+            imports: 'always-multiline',
+            exports: 'always-multiline',
+            functions: 'never',
+          },
+        ],
+        '@stylistic/block-spacing': ['error', 'always'],
+        '@stylistic/computed-property-spacing': ['error'],
+        '@stylistic/operator-linebreak': ['error'],
+        '@stylistic/function-call-spacing': ['error'],
+        '@stylistic/function-paren-newline': ['error'],
+      },
+    })
+  }
 
   if (initVuePlugin) {
     confArray.push(...vue.configs['flat/recommended'])
@@ -91,7 +96,7 @@ export const config = (props: ConfigProps) => {
 
   confArray.push({
     rules: {
-      'vue/block-order': [ 'error', { order: [ 'script', 'template', 'style' ] } ],
+      'vue/block-order': ['error', { order: ['script', 'template', 'style'] }],
     },
   })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import vue from 'eslint-plugin-vue'
 import stylistic from '@stylistic/eslint-plugin'
 import type { StylisticCustomizeOptions } from '@stylistic/eslint-plugin'
-import pluginTailwindCSS from 'eslint-plugin-tailwindcss'
+import pluginTailwindCSS from 'eslint-plugin-better-tailwindcss'
 import merge from 'deepmerge'
 
 export { default as prettier } from './prettier.js'
@@ -13,6 +13,8 @@ export type ConfigProps = {
   stylistic?: StylisticCustomizeOptions
   tailwindcss?: boolean
   tailwindcssConfig?: Record<string, unknown> & {
+    config?: string
+    version?: '4' | '3'
     customClassProperties?: string[]
   }
 }
@@ -22,7 +24,9 @@ const DefaultConfigProps: ConfigProps = {
   useStylisticPlugin: true,
   initStylisticPlugin: false,
   tailwindcss: true,
-  tailwindcssConfig: {},
+  tailwindcssConfig: {
+    version: '3',
+  },
 }
 
 export const config = (props: ConfigProps) => {
@@ -37,17 +41,24 @@ export const config = (props: ConfigProps) => {
   const confArray = []
 
   if (tailwindcss) {
-    const { customClassProperties, ...tailwindcssConfigRest } =
-      tailwindcssConfig
-    confArray.push(...pluginTailwindCSS.configs['flat/recommended'])
+    const {
+      version,
+      config: configFile,
+      customClassProperties,
+      ...tailwindcssConfigRest
+    } = tailwindcssConfig
+
+    confArray.push(pluginTailwindCSS)
     confArray.push({
       settings: {
-        tailwindcss: merge(
+        'better-tailwindcss': merge(
           {
-            cssFiles: ['src/**/*.{css,scss}'],
-            classRegex: customClassProperties
-              ? `^(${['class(Name)?', ...customClassProperties].join('|')})$`
-              : undefined,
+            [version === '3' ? 'tailwindConfig' : 'entryPoint']: configFile,
+            attributes: [
+              customClassProperties
+                ? `^(${['class(Name)?', ...customClassProperties].join('|')})$`
+                : undefined,
+            ].filter(Boolean),
           },
           tailwindcssConfigRest,
         ),

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ import type { StylisticCustomizeOptions } from '@stylistic/eslint-plugin'
 import pluginTailwindCSS from 'eslint-plugin-tailwindcss'
 import merge from 'deepmerge'
 
+export { default as prettier } from './prettier.js'
+
 export type ConfigProps = {
   initVuePlugin?: boolean
   initStylisticPlugin?: boolean
@@ -32,18 +34,20 @@ export const config = (props: ConfigProps) => {
   const confArray = []
 
   if (tailwindcss) {
-    const { customClassProperties, ...tailwindcssConfigRest } = tailwindcssConfig
+    const { customClassProperties, ...tailwindcssConfigRest }
+      = tailwindcssConfig
     confArray.push(...pluginTailwindCSS.configs['flat/recommended'])
     confArray.push({
       settings: {
-        tailwindcss: merge({
-          cssFiles: [
-            'src/**/*.{css,scss}',
-          ],
-          classRegex: customClassProperties
-            ? `^(${[ 'class(Name)?', ...customClassProperties ].join('|')})$`
-            : undefined,
-        }, tailwindcssConfigRest),
+        tailwindcss: merge(
+          {
+            cssFiles: [ 'src/**/*.{css,scss}' ],
+            classRegex: customClassProperties
+              ? `^(${[ 'class(Name)?', ...customClassProperties ].join('|')})$`
+              : undefined,
+          },
+          tailwindcssConfigRest
+        ),
       },
     })
   }
@@ -55,18 +59,24 @@ export const config = (props: ConfigProps) => {
   confArray.push({
     rules: {
       '@stylistic/max-len': [ 'error', { code: 120 } ],
-      '@stylistic/quotes': [ 2, 'single', { avoidEscape: true,
-        allowTemplateLiterals: false } ],
+      '@stylistic/quotes': [
+        2,
+        'single',
+        { avoidEscape: true, allowTemplateLiterals: false },
+      ],
       '@stylistic/arrow-parens': [ 'error', 'as-needed' ],
       '@stylistic/brace-style': [ 'error', '1tbs', { allowSingleLine: true } ],
       '@stylistic/array-bracket-spacing': [ 'error', 'always' ],
-      '@stylistic/comma-dangle': [ 'error', {
-        arrays: 'always-multiline',
-        objects: 'always-multiline',
-        imports: 'always-multiline',
-        exports: 'always-multiline',
-        functions: 'never',
-      } ],
+      '@stylistic/comma-dangle': [
+        'error',
+        {
+          arrays: 'always-multiline',
+          objects: 'always-multiline',
+          imports: 'always-multiline',
+          exports: 'always-multiline',
+          functions: 'never',
+        },
+      ],
       '@stylistic/block-spacing': [ 'error', 'always' ],
       '@stylistic/computed-property-spacing': [ 'error' ],
       '@stylistic/operator-linebreak': [ 'error' ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,11 @@ export const config = (props: ConfigProps) => {
       ...tailwindcssConfigRest
     } = tailwindcssConfig
 
-    confArray.push(pluginTailwindCSS)
+    confArray.push({
+      plugins: { 'better-tailwindcss': pluginTailwindCSS },
+      rules: { ...pluginTailwindCSS.configs['recommended-warn'].rules },
+    })
+
     confArray.push({
       settings: {
         'better-tailwindcss': merge(

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,14 +73,8 @@ export const config = (props: ConfigProps) => {
         ),
       },
       rules: {
-        ...(version === '4'
-          ? {
-              'better-tailwindcss/no-unregistered-classes': [
-                'warn',
-                { detectComponentClasses: true },
-              ],
-            }
-          : {}),
+        'better-tailwindcss/no-unregistered-classes':
+          version === '4' ? ['warn', { detectComponentClasses: true }] : 'off',
         'better-tailwindcss/enforce-consistent-line-wrapping': [
           'warn',
           {

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,16 +53,21 @@ export const config = (props: ConfigProps) => {
       rules: { ...pluginTailwindCSS.configs['recommended-warn'].rules },
     })
 
+    if (customClassProperties) {
+      confArray.push({
+        'better-tailwindcss': {
+          attributes: [
+            `^(${['class(Name)?', ...customClassProperties].join('|')})$`,
+          ],
+        },
+      })
+    }
+
     confArray.push({
       settings: {
         'better-tailwindcss': merge(
           {
             [version === '3' ? 'tailwindConfig' : 'entryPoint']: configFile,
-            attributes: [
-              customClassProperties
-                ? `^(${['class(Name)?', ...customClassProperties].join('|')})$`
-                : undefined,
-            ].filter(Boolean),
           },
           tailwindcssConfigRest,
         ),

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ export const config = (props: ConfigProps) => {
         'better-tailwindcss/enforce-consistent-line-wrapping': [
           'warn',
           {
-            group: 'newLine',
+            group: 'never',
             preferSingleLine: true,
             printWidth: 120,
             classesPerLine: 8,

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,25 @@ export const config = (props: ConfigProps) => {
           tailwindcssConfigRest,
         ),
       },
+      rules: {
+        ...(version === '4'
+          ? {
+              'better-tailwindcss/no-unregistered-classes': [
+                'warn',
+                { detectComponentClasses: 'never' },
+              ],
+            }
+          : {}),
+        'better-tailwindcss/enforce-consistent-line-wrapping': [
+          'warn',
+          {
+            group: 'newLine',
+            preferSingleLine: true,
+            printWidth: 120,
+            classesPerLine: 8,
+          },
+        ],
+      },
     })
   }
 

--- a/src/prettier.ts
+++ b/src/prettier.ts
@@ -1,0 +1,16 @@
+import type { Options } from 'prettier'
+
+const config: Options = {
+  trailingComma: 'none',
+  tabWidth: 2,
+  semi: false,
+  singleQuote: true,
+  overrides: [
+    {
+      files: [ '*.yaml', '*.yml' ],
+      options: { singleQuote: false },
+    },
+  ],
+}
+
+export default config

--- a/src/prettier.ts
+++ b/src/prettier.ts
@@ -1,13 +1,13 @@
 import type { Options } from 'prettier'
 
 const config: Options = {
-  trailingComma: 'none',
+  trailingComma: 'all',
   tabWidth: 2,
   semi: false,
   singleQuote: true,
   overrides: [
     {
-      files: [ '*.yaml', '*.yml' ],
+      files: ['*.yaml', '*.yml'],
       options: { singleQuote: false },
     },
   ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,14 +15,14 @@
     "sourceMap": true,
     "esModuleInterop": true,
     "isolatedModules": true,
-    
+
     /* Linting */
     "strict": true,
     "strictNullChecks": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "forceConsistentCasingInFileNames": true,
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["src", "types"],
   "exclude": ["node_modules", "dist"]

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,7 @@
 declare module 'eslint-plugin-tailwindcss' {
   export default {
     configs: {
-      'recommended': Record<string, unknown>,
+      recommended: Record<string, unknown>,
       'flat/recommended': Record<string, unknown>,
     },
   }


### PR DESCRIPTION
This pull request introduces significant changes to integrate Prettier into the codebase, enhance ESLint configurations, and refine TailwindCSS plugin usage. It includes updates to configuration files, dependencies, and documentation, as well as improvements to the `src/index.ts` file for better plugin handling and consistency.

### Prettier Integration:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L13-R14): Added the `esbenp.prettier-vscode` extension to the recommended extensions list.
* [`.prettierrc.mjs`](diffhunk://#diff-dc62c24c496f1ffc41710ff53afb1aa996177ac7d2b840ae89cac306ce894f2fR1-R2): Introduced Prettier configuration by importing and exporting settings from `@cewald/eslint-config`.
* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L3-R7): Enabled `editor.formatOnSave` and set Prettier as the default formatter.
* [`src/prettier.ts`](diffhunk://#diff-e2fdd7facdaca96bf442f6a2833a38f811870da73568afadfa48e3ad6c112af0R1-R16): Added a Prettier configuration file defining options such as trailing commas, tab width, and single quotes.

### ESLint Enhancements:

* [`eslint.config.mjs`](diffhunk://#diff-9601a8f6c734c2001be34a2361f76946d19a39a709b5e8c624a2a5a0aade05f2L9-R12): Updated ESLint configurations to disable stylistic plugin usage and refine Vue plugin initialization.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L47-R57): Added `eslint-config-prettier` and `prettier` dependencies, replacing `eslint-plugin-tailwindcss` with `eslint-plugin-better-tailwindcss`. Also added Prettier to the `lint-staged` commands for formatting.
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L4-R35): Enhanced ESLint configuration logic to support `better-tailwindcss` and added options for Prettier export. Introduced support for TailwindCSS versioning and refined stylistic rules. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L4-R35) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L35-R124)

### TailwindCSS Plugin Updates:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L35-R124): Replaced `eslint-plugin-tailwindcss` with `eslint-plugin-better-tailwindcss`, adding configuration options for TailwindCSS versions and custom class properties. Improved rules for consistent line wrapping and unregistered class detection.

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R25-R35): Updated instructions for enabling Prettier autoformatting in VSCode, providing configuration examples for both Prettier and non-Prettier setups.

### Miscellaneous:

* [`release.config.mjs`](diffhunk://#diff-eca83ee4cf455c21db5ffb94a45d3e7e779c21585879a29f626277c0406a6f2eL5): Removed the `branches` configuration for semantic release, simplifying the file.